### PR TITLE
Add flag to link with math library in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ For a deeper explination of how it works, [read this article](https://www.a1k0n.
 
 ## How to run
 
-`gcc donut.c && ./a.out`
+`gcc donut.c -lm && ./a.out`


### PR DESCRIPTION
Compile fails without linking to math  in GCC command. 

Output without flag:
```
donut.c:4:14: warning: data definition has no type or storage class
              k;double sin()
              ^
donut.c:4:14: warning: type defaults to ‘int’ in declaration of ‘k’ [-Wimplicit-int]
donut.c:5:17: warning: return type defaults to ‘int’ [-Wimplicit-int]
          ,cos();main(){float A=
                 ^~~~
/tmp/ccIA3Y71.o: In function `main':
donut.c:(.text+0xa0): undefined reference to `sin'
donut.c:(.text+0xb9): undefined reference to `cos'
donut.c:(.text+0xd2): undefined reference to `sin'
donut.c:(.text+0xeb): undefined reference to `sin'
donut.c:(.text+0x104): undefined reference to `cos'
donut.c:(.text+0x18b): undefined reference to `cos'
donut.c:(.text+0x1a4): undefined reference to `cos'
donut.c:(.text+0x1bd): undefined reference to `sin'
collect2: error: ld returned 1 exit status
```

